### PR TITLE
Add Abyssal Sire Plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/abyssalsire/AbyssalSireConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/abyssalsire/AbyssalSireConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019, Dennis III <https://github.com/Dennis-III>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.abyssalsire;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("abyssalsire")
+public interface AbyssalSireConfig extends Config
+{
+	@ConfigItem(
+		keyName = "walkUnderSpawn",
+		name = "Walk under Spawns",
+		description = "Left-click to walk under Spawns at Abyssal Sire",
+		position = 1
+	)
+	default boolean walkUnderSpawn()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "walkUnderScion",
+		name = "Walk under Scions",
+		description = "Left-click to walk under Scions at Abyssal Sire",
+		position = 2
+	)
+	default boolean walkUnderScion()
+	{
+		return true;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/abyssalsire/AbyssalSirePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/abyssalsire/AbyssalSirePlugin.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2019, Dennis III <https://github.com/Dennis-III>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.abyssalsire;
+
+import com.google.inject.Provides;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import static net.runelite.api.MenuAction.MENU_ACTION_DEPRIORITIZE_OFFSET;
+import static net.runelite.api.MenuAction.WALK;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.util.Text;
+
+@PluginDescriptor(
+	name = "Abyssal Sire",
+	description = "Left-click to walk under Spawns and Scions at Abyssal Sire",
+	tags = {"sire", "abyssal", "scion", "spawn"}
+)
+public class AbyssalSirePlugin extends Plugin
+{
+	@Inject
+	private AbyssalSireConfig config;
+
+	@Inject
+	private Client client;
+
+	@Provides
+	AbyssalSireConfig getConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(AbyssalSireConfig.class);
+	}
+
+	@Subscribe
+	public void onMenuEntryAdded(MenuEntryAdded event)
+	{
+		final String target = Text.removeTags(event.getTarget()).toLowerCase();
+		if ((config.walkUnderSpawn() && target.equals("spawn  (level-60)"))
+		|| (config.walkUnderScion() && target.equals("scion  (level-100)")))
+		{
+			if (event.getType() < WALK.getId())
+			{
+				MenuEntry[] menuEntries = client.getMenuEntries();
+				MenuEntry menuEntry = menuEntries[menuEntries.length - 1];
+				menuEntry.setType(event.getType() + MENU_ACTION_DEPRIORITIZE_OFFSET);
+				client.setMenuEntries(menuEntries);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add Abyssal Sire Plugin for toggling left-click to walk under Spawns and Scions.

This plugin improves the QoL of the Abyssal Sire by deprioritizing the Attack option on the Spawns and Scions, allowing you to left-click to walk on them. This plugin solves a similar problem for Abyssal Sire that the "left click walk on core" plugin option does for Corporeal Beast.

![abyssalsireplugin](https://user-images.githubusercontent.com/54224615/63395417-44940d00-c389-11e9-9e94-b6e8c0118351.PNG)
![abyssalsireplugin](https://user-images.githubusercontent.com/54224615/63395423-48c02a80-c389-11e9-919c-278d2883f9c6.gif)
